### PR TITLE
FIX: wrap tags assignment with DB transaction

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -28,9 +28,13 @@ after_initialize do
     end
     oss.select! {|os| [:macos, :windows].include? os }
 
-    topic.tags << mac if mac && oss.include?(:macos)
-    topic.tags << windows if windows && oss.include?(:windows)
 
-    topic.save!
+    ActiveRecord::Base.transaction do
+      topic.tags.reload
+      topic.tags << mac if mac && oss.include?(:macos)
+      topic.tags << windows if windows && oss.include?(:windows)
+
+      topic.save!
+    end
   end
 end


### PR DESCRIPTION
There are 2 plugins that are modifying tags almost at the same moment as :topic_created and :post_created events are triggered at the same moment.

Therefore, they can have conflict and one can destroy the effect of another
https://github.com/discourse/discourse-tag-topic-user-device
https://github.com/discourse/discourse-unhandled-tagger

The transaction should prevent that from happening

Corresponding PR https://github.com/discourse/discourse-unhandled-tagger/pull/1