### PR TITLE
FIX: do not add a tag if already exists

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -31,8 +31,8 @@ after_initialize do
 
     ActiveRecord::Base.transaction do
       topic.tags.reload
-      topic.tags << mac if mac && oss.include?(:macos)
-      topic.tags << windows if windows && oss.include?(:windows)
+      topic.tags << mac if mac && oss.include?(:macos) && !topic.tags.include?(mac)
+      topic.tags << windows if windows && oss.include?(:windows) && !topic.tags.include?(windows)
 
       topic.save!
     end


### PR DESCRIPTION
`windows` and `mac` tag can be picked by a user when creating a topic. In those cases that plugin is crashing because of `save!`.

We need to ensure that the tag doesn't already exist.