### PR TITLE
DEV: Refresh auto group in test

### DIFF
--- a/spec/components/topic_created_spec.rb
+++ b/spec/components/topic_created_spec.rb
@@ -1,35 +1,42 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Topic do
-  let(:user) { Fabricate(:user) }
-  let(:pc) { PostCreator.new(user, raw: 'this is the new content for my topic', title: 'this is my new topic title') }
+  let(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  let(:pc) do
+    PostCreator.new(
+      user,
+      raw: "this is the new content for my topic",
+      title: "this is my new topic title"
+    )
+  end
 
-  context 'by default' do
-    it 'does nothing with no tags' do
+  context "by default" do
+    it "does nothing with no tags" do
       _post = pc.create
       expect(_post.topic.tags).to be_empty
     end
   end
 
-  context 'it works' do
+  context "it works" do
     before do
       Tag.create(name: "mac")
       Tag.create(name: "windows")
     end
 
-    it 'does nothing if user has no mac/windows history' do
+    it "does nothing if user has no mac/windows history" do
       _post = pc.create
       expect(_post.topic.tags).to be_empty
     end
 
-    it 'can add mac tag' do
+    it "can add mac tag" do
       UserAuthToken.create(
         auth_token: "nada",
         prev_auth_token: "nada",
         auth_token_seen: true,
-        user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0",
+        user_agent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0",
         client_ip: "127.0.0.1",
         user_id: user.id,
         rotated_at: 1.day.ago,
@@ -43,12 +50,13 @@ describe Topic do
       expect(_post.topic.tags).not_to include(Tag.where(name: "windows").first)
     end
 
-    it 'can add windows tag' do
+    it "can add windows tag" do
       UserAuthToken.create(
         auth_token: "nadawin",
         prev_auth_token: "nadawin",
         auth_token_seen: true,
-        user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+        user_agent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
         client_ip: "127.0.0.1",
         user_id: user.id,
         rotated_at: 1.day.ago,
@@ -62,12 +70,13 @@ describe Topic do
       expect(_post.topic.tags).not_to include(Tag.where(name: "mac").first)
     end
 
-    it 'can add both' do
+    it "can add both" do
       UserAuthToken.create(
         auth_token: "nada",
         prev_auth_token: "nada",
         auth_token_seen: true,
-        user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0",
+        user_agent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0",
         client_ip: "127.0.0.1",
         user_id: user.id,
         rotated_at: 1.day.ago,
@@ -79,7 +88,8 @@ describe Topic do
         auth_token: "nadawin",
         prev_auth_token: "nadawin",
         auth_token_seen: true,
-        user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+        user_agent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
         client_ip: "127.0.0.1",
         user_id: user.id,
         rotated_at: 1.day.ago,
@@ -93,14 +103,15 @@ describe Topic do
       expect(_post.topic.tags).to include(Tag.where(name: "mac").first)
     end
 
-    it 'does not apply tag for staff user' do
+    it "does not apply tag for staff user" do
       user.update!(admin: true)
 
       UserAuthToken.create(
         auth_token: "nadawin",
         prev_auth_token: "nadawin",
         auth_token_seen: true,
-        user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+        user_agent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
         client_ip: "127.0.0.1",
         user_id: user.id,
         rotated_at: 1.day.ago,
@@ -112,8 +123,6 @@ describe Topic do
 
       expect(_post.topic.tags).not_to include(Tag.where(name: "windows").first)
       expect(_post.topic.tags).not_to include(Tag.where(name: "mac").first)
-
     end
-
   end
 end


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/24257

Due to changes in site settings related to trust level, we must now `refresh_auto_groups` when we fab users.